### PR TITLE
fix tests and set id optional on SystemType

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ type ComponentData = {
 
 export const Engine = darkerEngine<IEntities, IComponents, ComponentData>()
 
-const exampleEntity = (): EntityType<IEntities, IComponents, ComponentData> => ({
+const exampleEntity: EntityTypeFunction<IEntities, IComponents, ComponentData> = () => ({
   id: Engine.getUID(),
   type: IEntities.EXAMPLE_ENTITY,
   data: {
@@ -154,17 +154,17 @@ const exampleSystem: SystemFunction<IComponents> = () => {
 
   const onAdd = (id: number) => {
     const entity = Engine.getEntity(id);
-    entity.updateComponent?.(IComponents.EXAMPLE_COMPONENT, { foo: "fii" });
+    entity.updateComponent(IComponents.EXAMPLE_COMPONENT, { foo: 'fii'});
   }
 
-  const onUpdate = (id: number, component: IComponents) => {
+  const onUpdate = (id: number, component?: IComponents) => {
     const entity = Engine.getEntity(id);
 
     if (component !== IComponents.EXAMPLE_COMPONENT) return;
 
-    const { foo } = entity.getComponent?.(IComponents.EXAMPLE_COMPONENT);
-    if (foo === "fii" && !entity.hasComponent?.(IComponents.OTHER_COMPONENT)) {
-      entity.removeComponent?.(IComponents.EXAMPLE_COMPONENT);
+    const { foo } = entity.getComponent(IComponents.EXAMPLE_COMPONENT);
+    if (foo === "fii" && !entity.hasComponent(IComponents.OTHER_COMPONENT)) {
+      entity.removeComponent(IComponents.EXAMPLE_COMPONENT);
     }
   }
 
@@ -185,4 +185,5 @@ const exampleSystem: SystemFunction<IComponents> = () => {
 
 Engine.setSystems(exampleSystem);
 Engine.load()
+
 ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ npm install darker-engine
 ```ts
 import { engine as darkerEngine } from "darker-engine";
 
-export const Engine = darkerEngine();
+export const Engine = darkerEngine<IEntities, IComponents, ComponentData>();
 
 Engine.setSystems(...[]);
 
@@ -59,7 +59,7 @@ enum Components {
 ```ts
 import { EntityType } from "darker-engine";
 
-const exampleEntity = (): EntityType => ({
+const exampleEntity = (): EntityType<IEntities, IComponents, ComponentData> => ({
   id: Engine.getUID(),
   type: EntityType.EXAMPLE,
   data: {},
@@ -72,7 +72,7 @@ const exampleEntity = (): EntityType => ({
 ```ts
 import { SystemFunction } from "darker-engine";
 
-const exampleSystem: SystemFunction = () => {
+const exampleSystem: SystemFunction<IComponents> = () => {
   const onAdd = (entityId: number) => {};
   const onUpdate = (entityId: number, component: string) => {};
   const onRemove = (entityId: number) => {};
@@ -95,8 +95,6 @@ import {
   SystemFunction,
 } from "darker-engine";
 
-export const Engine = darkerEngine()
-
 enum IEntities {
   EXAMPLE_ENTITY,
 }
@@ -106,7 +104,18 @@ enum IComponents {
   OTHER_COMPONENT,
 }
 
-const exampleEntity = (): EntityType => ({
+type ComponentData = {
+  [IComponents.EXAMPLE_COMPONENT]: {
+    foo: string;
+  },
+  [IComponents.OTHER_COMPONENT]: {
+    bar: number;
+  };
+};
+
+export const Engine = darkerEngine<IEntities, IComponents, ComponentData>()
+
+const exampleEntity = (): EntityType<IEntities, IComponents, ComponentData> => ({
   id: Engine.getUID(),
   type: IEntities.EXAMPLE_ENTITY,
   data: {
@@ -117,7 +126,7 @@ const exampleEntity = (): EntityType => ({
   components: [IComponents.EXAMPLE_COMPONENT],
 })
 
-const exampleSystem: SystemFunction = () => {
+const exampleSystem: SystemFunction<IComponents> = () => {
   let interval: number
 
   const onLoad = () => {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,4 +1,11 @@
-import { DarkerMap, EngineType, EntityType, SystemFunction, SystemType } from './types.ts';
+import {
+	DarkerMap,
+	EngineType,
+	EntityType,
+	SimpleEntityType,
+	SystemFunction,
+	SystemType,
+} from './types.ts';
 import { uid } from './uid.ts';
 
 export const engine = <I extends string | number, C extends string | number, D>(): EngineType<
@@ -64,7 +71,7 @@ export const engine = <I extends string | number, C extends string | number, D>(
 	const _entity_updateComponent = (
 		entityId: number,
 		component: C,
-		data: any ,
+		data: any,
 	) => {
 		const entity = getEntity(entityId);
 		if (!entityComponentMap[entityId]?.includes(component)) {
@@ -142,7 +149,7 @@ export const engine = <I extends string | number, C extends string | number, D>(
 		entityId: number,
 		component: T,
 		deepClone = false,
-	): D[T] | undefined => {
+	): D[T] => {
 		const entityData = entityDataMap[entityId];
 
 		return entityData && entityData[component]
@@ -183,9 +190,11 @@ export const engine = <I extends string | number, C extends string | number, D>(
 
 	const getEntity = (entityId: number) => entityList[entityId];
 
-	const addEntity = (...entities: EntityType<I, C, D>[]): EntityType<I, C, D>[] => {
+	const addEntity = (...rawEntities: SimpleEntityType<I, C, D>[]): EntityType<I, C, D>[] => {
 		const date = Date.now();
-		entities.forEach((entity) => {
+		const entities = rawEntities.map((rawEntity) => {
+			const entity = rawEntity as EntityType<I, C, D>;
+			entity.id = entity.id ?? getUID();
 			entity.getData = () => _entity_getData(entity.id);
 			entity.getComponent = (component, deepClone) =>
 				_entity_getComponent(entity.id, component, deepClone);
@@ -207,6 +216,7 @@ export const engine = <I extends string | number, C extends string | number, D>(
 				[b]: (acc as any)[b] || {},
 			}), entity.data) ?? {};
 			entityList[entity.id] = entity;
+			return entity;
 		});
 
 		entities.forEach((entity) => {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -22,7 +22,7 @@ export const engine = <I extends string | number, C extends string | number, D>(
 		systemEntitiesMap = [];
 
 		_systems.forEach((system) => {
-			const _system = system();
+			const _system = system() as SystemType<C>;
 			_system.id = _system.id ?? getUID();
 			systemEntitiesMap[_system.id] = [];
 			systems[_system.id] = _system;
@@ -64,7 +64,7 @@ export const engine = <I extends string | number, C extends string | number, D>(
 	const _entity_updateComponent = (
 		entityId: number,
 		component: C,
-		data = {},
+		data: any ,
 	) => {
 		const entity = getEntity(entityId);
 		if (!entityComponentMap[entityId]?.includes(component)) {
@@ -193,7 +193,7 @@ export const engine = <I extends string | number, C extends string | number, D>(
 			entity.hasComponent = (component) => _entity_hasComponent(entity.id, component);
 			entity.removeComponent = (component) => _entity_removeComponent(entity.id, component);
 			entity.updateComponent = (component, data) =>
-				_entity_updateComponent(entity.id, component, data as any);
+				_entity_updateComponent(entity.id, component as unknown as C, data);
 
 			if (!typeEntityMap[entity.type]) {
 				typeEntityMap[entity.type] = [];
@@ -202,9 +202,9 @@ export const engine = <I extends string | number, C extends string | number, D>(
 
 			entityComponentMap[entity.id] = entity.components;
 
-			entityDataMap[entity.id] = entity?.getComponents?.().reduce((a, b) => ({
-				...a,
-				[b]: a[b] || {},
+			entityDataMap[entity.id] = entity?.getComponents?.().reduce((acc, b) => ({
+				...acc,
+				[b]: (acc as any)[b] || {},
 			}), entity.data) ?? {};
 			entityList[entity.id] = entity;
 		});

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,7 +36,7 @@ export interface SystemType<C> {
 	onDestroy?: () => void;
 }
 
-export type SystemFunction<C> = () => SystemType<C>;
+export type SystemFunction<C> = () => Omit<SystemType<C>, 'id'>;
 
 /**
  * Entity
@@ -56,7 +56,7 @@ export interface EntityType<I, C extends string | number, D> {
 	) => D[T] | undefined;
 	getComponents?: () => C[];
 	hasComponent?: (component: number) => boolean;
-	updateComponent?: UpdateComponentFunctionType<C>;
+	updateComponent?: <T extends keyof D>(component: T, data?: D[T]) => void;
 	removeComponent?: RemoveComponentFunctionType<C>;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export interface EngineType<I, C extends string | number, D> {
 	getEntityListByComponents: (...componentList: C[]) => EntityType<I, C, D>[];
 
 	getEntity: (id: number) => EntityType<I, C, D>;
-	addEntity: (...entities: EntityType<I, C, D>[]) => EntityType<I, C, D>[];
+	addEntity: (...entities: SimpleEntityType<I, C, D>[]) => EntityType<I, C, D>[];
 	removeEntity: (...idList: number[]) => void;
 
 	getSystem: (name: number) => SystemType<C> | undefined;
@@ -44,21 +44,33 @@ export type SystemFunction<C> = () => Omit<SystemType<C>, 'id'>;
 
 export interface EntityType<I, C extends string | number, D> {
 	//Only initial declaration
-	readonly id: number;
 	readonly type: I;
 	readonly data: Partial<D>;
 	readonly components: C[];
 
-	getData?: () => Record<number, any>;
-	getComponent?: <T extends keyof D>(
+	id: number;
+	getData: () => Record<number, any>;
+	getComponent: <T extends keyof D>(
 		component: T,
 		deepClone?: boolean,
-	) => D[T] | undefined;
-	getComponents?: () => C[];
-	hasComponent?: (component: number) => boolean;
-	updateComponent?: <T extends keyof D>(component: T, data?: D[T]) => void;
-	removeComponent?: RemoveComponentFunctionType<C>;
+	) => D[T];
+	getComponents: () => C[];
+	hasComponent: (component: number) => boolean;
+	updateComponent: <T extends keyof D>(component: T, data?: D[T]) => void;
+	removeComponent: RemoveComponentFunctionType<C>;
 }
+
+export type SimpleEntityType<I, C extends string | number, D> = Omit<
+	EntityType<I, C, D>,
+	| 'getData'
+	| 'getComponent'
+	| 'getComponents'
+	| 'hasComponent'
+	| 'updateComponent'
+	| 'removeComponent'
+>;
+
+export type EntityTypeFunction<I, C extends string | number, D> = () => SimpleEntityType<I, C, D>;
 
 export type UpdateComponentFunctionType<C> = <ComponentType>(
 	component: C,

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,10 +72,6 @@ export type SimpleEntityType<I, C extends string | number, D> = Omit<
 
 export type EntityTypeFunction<I, C extends string | number, D> = () => SimpleEntityType<I, C, D>;
 
-export type UpdateComponentFunctionType<C> = <ComponentType>(
-	component: C,
-	data: ComponentType,
-) => void;
 export type RemoveComponentFunctionType<C> = (component: C) => void;
 
 export type DarkerMap<T extends string | number, S> = { [key in T]: S };

--- a/tests/engine.test.ts
+++ b/tests/engine.test.ts
@@ -5,10 +5,10 @@ import {
 } from 'https://deno.land/std@0.195.0/testing/asserts.ts';
 
 import { engine, SystemFunction } from '../src/index.ts';
-import { Component, Entity, getEntity, System } from './utils.ts';
+import { Component, ComponentData, Entity, getEntity, System } from './utils.ts';
 
 Deno.test('Engine', async (test) => {
-	const Engine = engine<Entity, Component, any>();
+	const Engine = engine<Entity, Component, ComponentData>();
 
 	await test.step('expect Engine.getUID to be 1', () => {
 		assertEquals(Engine.getUID(), 1);
@@ -39,15 +39,15 @@ Deno.test('Engine', async (test) => {
 
 	await test.step('expect Engine.getEntityList to have 6 element', () => {
 		Engine.addEntity(
-			getEntity(Engine.getUID(), Entity.EXAMPLE_A, {}, []),
-			getEntity(Engine.getUID(), Entity.EXAMPLE_A, {}, [Component.COMPONENT_A]),
-			getEntity(Engine.getUID(), Entity.EXAMPLE_B, {}, []),
-			getEntity(Engine.getUID(), Entity.EXAMPLE_B, {}, [Component.COMPONENT_A]),
+			getEntity(Engine.getUID(), Entity.EXAMPLE_A, {}, [])(),
+			getEntity(Engine.getUID(), Entity.EXAMPLE_A, {}, [Component.COMPONENT_A])(),
+			getEntity(Engine.getUID(), Entity.EXAMPLE_B, {}, [])(),
+			getEntity(Engine.getUID(), Entity.EXAMPLE_B, {}, [Component.COMPONENT_A])(),
 			getEntity(Engine.getUID(), Entity.EXAMPLE_C, {}, [
 				Component.COMPONENT_A,
 				Component.COMPONENT_B,
-			]),
-			getEntity(Engine.getUID(), Entity.EXAMPLE_D, {}, [Component.COMPONENT_B]),
+			])(),
+			getEntity(Engine.getUID(), Entity.EXAMPLE_D, {}, [Component.COMPONENT_B])(),
 		);
 		assert(Engine.getEntityList().length === 6);
 	});

--- a/tests/engine.test.ts
+++ b/tests/engine.test.ts
@@ -5,10 +5,10 @@ import {
 } from 'https://deno.land/std@0.195.0/testing/asserts.ts';
 
 import { engine, SystemFunction } from '../src/index.ts';
-import { Component, getEntity, System } from './utils.ts';
+import { Component, Entity, getEntity, System } from './utils.ts';
 
 Deno.test('Engine', async (test) => {
-	const Engine = engine();
+	const Engine = engine<Entity, Component, any>();
 
 	await test.step('expect Engine.getUID to be 1', () => {
 		assertEquals(Engine.getUID(), 1);
@@ -23,7 +23,7 @@ Deno.test('Engine', async (test) => {
 	});
 
 	await test.step('expect Engine.setSystems to add a system', () => {
-		const system: SystemFunction = () => ({
+		const system: SystemFunction<Component> = () => ({
 			id: System.SYSTEM_B,
 			components: [],
 		});
@@ -39,33 +39,33 @@ Deno.test('Engine', async (test) => {
 
 	await test.step('expect Engine.getEntityList to have 6 element', () => {
 		Engine.addEntity(
-			getEntity(Engine.getUID(), 0, {}, []),
-			getEntity(Engine.getUID(), 0, {}, [Component.COMPONENT_A]),
-			getEntity(Engine.getUID(), 1, {}, []),
-			getEntity(Engine.getUID(), 1, {}, [Component.COMPONENT_A]),
-			getEntity(Engine.getUID(), 2, {}, [
+			getEntity(Engine.getUID(), Entity.EXAMPLE_A, {}, []),
+			getEntity(Engine.getUID(), Entity.EXAMPLE_A, {}, [Component.COMPONENT_A]),
+			getEntity(Engine.getUID(), Entity.EXAMPLE_B, {}, []),
+			getEntity(Engine.getUID(), Entity.EXAMPLE_B, {}, [Component.COMPONENT_A]),
+			getEntity(Engine.getUID(), Entity.EXAMPLE_C, {}, [
 				Component.COMPONENT_A,
 				Component.COMPONENT_B,
 			]),
-			getEntity(Engine.getUID(), 3, {}, [Component.COMPONENT_B]),
+			getEntity(Engine.getUID(), Entity.EXAMPLE_D, {}, [Component.COMPONENT_B]),
 		);
 		assert(Engine.getEntityList().length === 6);
 	});
 
 	await test.step('expect Engine.getEntityListByType with type 0 to have 2 entity', () => {
-		assert(Engine.getEntityListByType(0).length === 2);
+		assert(Engine.getEntityListByType(Entity.EXAMPLE_A).length === 2);
 	});
 
 	await test.step('expect Engine.getEntityListByType with type 1 to have 2 entity', () => {
-		assert(Engine.getEntityListByType(1).length === 2);
+		assert(Engine.getEntityListByType(Entity.EXAMPLE_B).length === 2);
 	});
 
 	await test.step('expect Engine.getEntityListByType with type 2 to have 1 entity', () => {
-		assert(Engine.getEntityListByType(2).length === 1);
+		assert(Engine.getEntityListByType(Entity.EXAMPLE_C).length === 1);
 	});
 
 	await test.step('expect Engine.getEntityListByType with type 3 to have 1 entity', () => {
-		assert(Engine.getEntityListByType(3).length === 1);
+		assert(Engine.getEntityListByType(Entity.EXAMPLE_D).length === 1);
 	});
 
 	await test.step('expect Engine.getEntityListByComponents with no components to have 6 entity', () => {

--- a/tests/entity.test.ts
+++ b/tests/entity.test.ts
@@ -1,11 +1,11 @@
 import { assertEquals, assertNotEquals } from 'https://deno.land/std@0.195.0/testing/asserts.ts';
 import { spy } from 'https://deno.land/std@0.195.0/testing/mock.ts';
 
-import { engine, SystemFunction } from '../src/index.ts';
-import { Component, Entity, getEntity, System } from './utils.ts';
+import { engine, EntityType, SystemFunction } from '../src/index.ts';
+import { Component, ComponentData, Entity, getEntity, System } from './utils.ts';
 
 Deno.test('Entity', async (test) => {
-	const Engine = engine<Entity, Component, any>();
+	const Engine = engine<Entity, Component, ComponentData>();
 
 	const onAddSystemAMock = spy(() => {});
 	const onAddSystemBMock = spy(() => {});
@@ -22,7 +22,7 @@ Deno.test('Entity', async (test) => {
 	});
 	Engine.setSystems(systemA, systemB);
 
-	const entityA = getEntity(Engine.getUID(), 0);
+	const entityA = getEntity(Engine.getUID(), 0)() as EntityType<Entity, Component, ComponentData>;
 
 	await test.step('expect add an entity', () => {
 		Engine.addEntity(entityA);
@@ -39,7 +39,7 @@ Deno.test('Entity', async (test) => {
 	});
 
 	await test.step('expect raw data to be empty', () => {
-		assertEquals(entityA?.getData?.(), {});
+		assertEquals(entityA.getData(), {});
 	});
 
 	const componentData = {
@@ -49,13 +49,13 @@ Deno.test('Entity', async (test) => {
 	await test.step('expect update component data', () => {
 		Engine.addEntity(entityA);
 
-		entityA?.updateComponent?.(Component.COMPONENT_A, componentData);
+		entityA.updateComponent(Component.COMPONENT_A, componentData);
 
-		assertEquals(entityA?.getComponent?.(Component.COMPONENT_A), componentData);
+		assertEquals(entityA.getComponent(Component.COMPONENT_A), componentData);
 	});
 
 	await test.step('expect entity raw data to contain data', () => {
-		assertEquals(entityA?.getData?.(), {
+		assertEquals(entityA.getData(), {
 			[Component.COMPONENT_A]: componentData,
 		});
 	});
@@ -65,9 +65,9 @@ Deno.test('Entity', async (test) => {
 
 		const componentData = { foo: 'faa', fii: 123 };
 
-		entityA?.updateComponent?.(Component.COMPONENT_C, componentData);
+		entityA.updateComponent(Component.COMPONENT_C, componentData);
 
-		assertEquals(entityA?.hasComponent?.(Component.COMPONENT_C), true);
-		assertEquals(entityA?.getComponent?.(Component.COMPONENT_C), componentData);
+		assertEquals(entityA.hasComponent(Component.COMPONENT_C), true);
+		assertEquals(entityA.getComponent(Component.COMPONENT_C), componentData);
 	});
 });

--- a/tests/entity.test.ts
+++ b/tests/entity.test.ts
@@ -2,20 +2,20 @@ import { assertEquals, assertNotEquals } from 'https://deno.land/std@0.195.0/tes
 import { spy } from 'https://deno.land/std@0.195.0/testing/mock.ts';
 
 import { engine, SystemFunction } from '../src/index.ts';
-import { Component, getEntity, System } from './utils.ts';
+import { Component, Entity, getEntity, System } from './utils.ts';
 
 Deno.test('Entity', async (test) => {
-	const Engine = engine();
+	const Engine = engine<Entity, Component, any>();
 
 	const onAddSystemAMock = spy(() => {});
 	const onAddSystemBMock = spy(() => {});
 
-	const systemA: SystemFunction = () => ({
+	const systemA: SystemFunction<Component> = () => ({
 		id: System.SYSTEM_A,
 		components: [Component.COMPONENT_A],
 		onAdd: onAddSystemAMock,
 	});
-	const systemB: SystemFunction = () => ({
+	const systemB: SystemFunction<Component> = () => ({
 		id: System.SYSTEM_B,
 		components: [Component.COMPONENT_A, Component.COMPONENT_B],
 		onAdd: onAddSystemBMock,

--- a/tests/system.test.ts
+++ b/tests/system.test.ts
@@ -9,10 +9,10 @@ import {
 } from 'https://deno.land/std@0.195.0/testing/mock.ts';
 
 import { engine, SystemFunction } from '../src/index.ts';
-import { Component, getEntity, System } from './utils.ts';
+import { Component, Entity, getEntity, System } from './utils.ts';
 
 Deno.test('System', async (test) => {
-	const Engine = engine();
+	const Engine = engine<Entity, Component, any>();
 
 	const onAddSystemAMock = spy(() => {});
 	const onAddSystemBMock = spy(() => {});
@@ -29,7 +29,7 @@ Deno.test('System', async (test) => {
 	const onDestroySystemAMock = spy(() => {});
 	const onDestroySystemBMock = spy(() => {});
 
-	const systemA: SystemFunction = () => ({
+	const systemA: SystemFunction<Component> = () => ({
 		id: System.SYSTEM_A,
 		components: [Component.COMPONENT_A],
 		onAdd: onAddSystemAMock,
@@ -38,7 +38,7 @@ Deno.test('System', async (test) => {
 		onLoad: onLoadSystemAMock,
 		onDestroy: onDestroySystemAMock,
 	});
-	const systemB: SystemFunction = () => ({
+	const systemB: SystemFunction<Component> = () => ({
 		id: System.SYSTEM_B,
 		components: [Component.COMPONENT_A, Component.COMPONENT_B],
 		onAdd: onAddSystemBMock,

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,4 +1,4 @@
-import { EntityType } from '../src/index.ts';
+import { EntityTypeFunction } from '../src/index.ts';
 
 export enum Entity {
 	EXAMPLE_A,
@@ -18,12 +18,19 @@ export enum Component {
 	COMPONENT_C,
 }
 
+export type ComponentData = {
+	[Component.COMPONENT_A]: {};
+	[Component.COMPONENT_B]: {};
+	[Component.COMPONENT_C]: {};
+};
+
 export const getEntity = (
 	id: number,
-	type: number = Entity.EXAMPLE_A,
+	type: Entity = Entity.EXAMPLE_A,
 	data = {},
-	components: number[] = [],
-): EntityType<Entity, Component, any> => ({
+	components: Component[] = [],
+): EntityTypeFunction<Entity, Component, ComponentData> =>
+() => ({
 	id,
 	type,
 	data,

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -2,6 +2,9 @@ import { EntityType } from '../src/index.ts';
 
 export enum Entity {
 	EXAMPLE_A,
+	EXAMPLE_B,
+	EXAMPLE_C,
+	EXAMPLE_D,
 }
 
 export enum System {
@@ -18,9 +21,9 @@ export enum Component {
 export const getEntity = (
 	id: number,
 	type: number = Entity.EXAMPLE_A,
-	data: Record<number, unknown> = {},
+	data = {},
 	components: number[] = [],
-): EntityType => ({
+): EntityType<Entity, Component, any> => ({
 	id,
 	type,
 	data,


### PR DESCRIPTION
Close #8 

## Changes
- Fix tests
- Typed data on updateComponent function
- Optional id on `SystemType`
- Update README
- Added `EntityTypeFunction` with `SimpleEntityType` -> no more `?.`
~~`const { foo } = entity.getComponent?.(IComponents.EXAMPLE_COMPONENT);`~~
`const { foo } = entity.getComponent(IComponents.EXAMPLE_COMPONENT);`

## Advice
Change type `EntityType` to `EntityTypeFunction<IEntities, IComponents, ComponentData>` on all your functions than create entities