### PR TITLE
feat(entity): add getComponentsData and return entity on updateComponent

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -143,7 +143,7 @@ export const engine = <I extends string | number, C extends string | number, D>(
 	};
 
 	// TODO: maintain original order, not this shit
-	const _entity_getComponents = (entityId: number) => entityComponentMap[entityId];
+	const _entity_getComponentTypes = (entityId: number) => entityComponentMap[entityId];
 
 	const _entity_getComponent = <T extends keyof D>(
 		entityId: number,
@@ -159,7 +159,7 @@ export const engine = <I extends string | number, C extends string | number, D>(
 			: {};
 	};
 
-	const _entity_getComponentsData = <T extends keyof D>(
+	const _entity_getComponents = <T extends keyof D>(
 		entityId: number,
 		components: T[],
 		deepClone = false,
@@ -214,9 +214,9 @@ export const engine = <I extends string | number, C extends string | number, D>(
 			entity.getData = () => _entity_getData(entity.id);
 			entity.getComponent = (component, deepClone) =>
 				_entity_getComponent(entity.id, component, deepClone);
-			entity.getComponents = () => _entity_getComponents(entity.id);
-			entity.getComponentsData = (components, deepClone) =>
-				_entity_getComponentsData(entity.id, components, deepClone);
+			entity.getComponentTypes = () => _entity_getComponentTypes(entity.id);
+			entity.getComponents = (components, deepClone) =>
+				_entity_getComponents(entity.id, components, deepClone);
 			entity.hasComponent = (component) => _entity_hasComponent(entity.id, component);
 			entity.removeComponent = (component) => _entity_removeComponent(entity.id, component);
 			entity.updateComponent = (component, data) =>
@@ -229,7 +229,7 @@ export const engine = <I extends string | number, C extends string | number, D>(
 
 			entityComponentMap[entity.id] = entity.components;
 
-			entityDataMap[entity.id] = entity?.getComponents?.().reduce((acc, b) => ({
+			entityDataMap[entity.id] = entity?.getComponentTypes?.().reduce((acc, b) => ({
 				...acc,
 				[b]: (acc as any)[b] || {},
 			}), entity.data) ?? {};
@@ -284,7 +284,7 @@ export const engine = <I extends string | number, C extends string | number, D>(
 		const _entityList = entityIdList.map((entityId) => entityList[entityId]);
 		_entityList.map((entity) => {
 			if (!entity) return;
-			const componentEntityList = entity?.getComponents?.();
+			const componentEntityList = entity?.getComponentTypes?.();
 			if (!componentEntityList) return;
 
 			// Calculate points from component order.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -159,6 +159,22 @@ export const engine = <I extends string | number, C extends string | number, D>(
 			: {};
 	};
 
+	const _entity_getComponentsData = <T extends keyof D>(
+		entityId: number,
+		components: T[],
+		deepClone = false,
+	): { [K in T]: D[K] } => {
+		const entityData = entityDataMap[entityId];
+
+		return components.reduce((acc, component) => {
+			const data = entityData[component];
+			if (!data) return acc;
+
+			acc[component] = deepClone ? structuredClone(data) : data;
+			return acc;
+		}, {} as { [K in T]: D[K] });
+	};
+
 	const _entity_hasComponent = (entityId: number, component: any) =>
 		entityComponentMap[entityId]?.includes(component);
 
@@ -199,6 +215,8 @@ export const engine = <I extends string | number, C extends string | number, D>(
 			entity.getComponent = (component, deepClone) =>
 				_entity_getComponent(entity.id, component, deepClone);
 			entity.getComponents = () => _entity_getComponents(entity.id);
+			entity.getComponentsData = (components, deepClone) =>
+				_entity_getComponentsData(entity.id, components, deepClone);
 			entity.hasComponent = (component) => _entity_hasComponent(entity.id, component);
 			entity.removeComponent = (component) => _entity_removeComponent(entity.id, component);
 			entity.updateComponent = (component, data) =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,14 +54,15 @@ export interface EntityType<I, C extends string | number, D> {
 		component: T,
 		deepClone?: boolean,
 	) => D[T];
-	getComponentsData: <T extends keyof D>(
+	getComponents: <T extends keyof D>(
 		components: T[],
 		deepClone?: boolean,
 	) => { [K in T]: D[K] };
-	getComponents: () => C[];
+	getComponentTypes: () => C[],
 	hasComponent: (component: number) => boolean;
 	updateComponent: <T extends keyof D>(component: T, data?: D[T]) => EntityType<I, C, D>;
 	removeComponent: (component: C) => void;
+	
 }
 
 export type SimpleEntityType<I, C extends string | number, D> = Omit<
@@ -69,7 +70,7 @@ export type SimpleEntityType<I, C extends string | number, D> = Omit<
 	| 'getData'
 	| 'getComponent'
 	| 'getComponents'
-	| 'getComponentsData'
+	| 'getComponentTypes'
 	| 'hasComponent'
 	| 'updateComponent'
 	| 'removeComponent'

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,10 +54,14 @@ export interface EntityType<I, C extends string | number, D> {
 		component: T,
 		deepClone?: boolean,
 	) => D[T];
+	getComponentsData: <T extends keyof D>(
+		components: T[],
+		deepClone?: boolean,
+	) => { [K in T]: D[K] };
 	getComponents: () => C[];
 	hasComponent: (component: number) => boolean;
-	updateComponent: <T extends keyof D>(component: T, data?: D[T]) => void;
-	removeComponent: RemoveComponentFunctionType<C>;
+	updateComponent: <T extends keyof D>(component: T, data?: D[T]) => EntityType<I, C, D>;
+	removeComponent: (component: C) => void;
 }
 
 export type SimpleEntityType<I, C extends string | number, D> = Omit<
@@ -65,13 +69,12 @@ export type SimpleEntityType<I, C extends string | number, D> = Omit<
 	| 'getData'
 	| 'getComponent'
 	| 'getComponents'
+	| 'getComponentsData'
 	| 'hasComponent'
 	| 'updateComponent'
 	| 'removeComponent'
 >;
 
 export type EntityTypeFunction<I, C extends string | number, D> = () => SimpleEntityType<I, C, D>;
-
-export type RemoveComponentFunctionType<C> = (component: C) => void;
 
 export type DarkerMap<T extends string | number, S> = { [key in T]: S };

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,11 +58,10 @@ export interface EntityType<I, C extends string | number, D> {
 		components: T[],
 		deepClone?: boolean,
 	) => { [K in T]: D[K] };
-	getComponentTypes: () => C[],
+	getComponentTypes: () => C[];
 	hasComponent: (component: number) => boolean;
 	updateComponent: <T extends keyof D>(component: T, data?: D[T]) => EntityType<I, C, D>;
 	removeComponent: (component: C) => void;
-	
 }
 
 export type SimpleEntityType<I, C extends string | number, D> = Omit<


### PR DESCRIPTION
Close #10 and #11 

- Arreglado tipo `updateComponent` para que devuelva la propia entidad
- Añadida función `getComponentsData` en entity para obtener todos los datos de los componentes de una. 

![image](https://github.com/darkaqua/darker-engine/assets/9885515/562377f5-451d-4f6b-ae90-344ead9788ad)

@pagoru quizá el nombre de la función `getComponentsData` no es correcto y deberia ser `getComponents` igual que esta `getComponent` cuando solo obtienes un dato. Pero `getComponents` ya se usa para obtener el listado de componentes de esa entidad